### PR TITLE
Added systemd service unit for a persistent Weave Net to Wireguard route

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ The added route will not survive a reboot as it is not persistent. To ensure tha
 After that we have to enable it by running following command:
 
 ```sh
-systemctl enable weave-route.service
+systemctl enable overlay-route.service
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -340,9 +340,9 @@ ip route add 10.96.0.0/16 dev wg0 src 10.0.1.3
 The added route will not survive a reboot as it is not persistent. To ensure that the route gets added after a reboot, we have to add a *systemd* service unit on each node which will wait for the wireguard interface to come up and after that adds the route. For kube1 it would look like this:
 
 ```sh
-# /etc/systemd/system/weave-route.service
+# /etc/systemd/system/overlay-route.service
 [Unit]
- Description=Weave Net Wireguard route
+ Description=Overlay network route for Wireguard
  After=wg-quick@wg0.service
 
 [Service]

--- a/README.md
+++ b/README.md
@@ -337,6 +337,30 @@ ip route add 10.96.0.0/16 dev wg0 src 10.0.1.2
 ip route add 10.96.0.0/16 dev wg0 src 10.0.1.3
 ```
 
+The added route will not survive a reboot as it is not persistent. To ensure that the route gets added after a reboot, we have to add a *systemd* service unit on each node which will wait for the wireguard interface to come up and after that adds the route. For kube1 it would look like this:
+
+```sh
+# /etc/systemd/system/weave-route.service
+[Unit]
+ Description=Weave Net Wireguard route
+ After=wg-quick@wg0.service
+
+[Service]
+ Type=oneshot
+ User=root
+ ExecStart=/sbin/ip route add 10.96.0.0/16 dev wg0 src 10.0.1.1
+
+[Install]
+ WantedBy=multi-user.target
+```
+
+After that we have to enable it by running following command:
+
+```sh
+systemctl enable weave-route.service
+```
+
+
 #### Joining the cluster nodes
 
 All that's left is to join the cluster with the other nodes. Run the following command on each host:


### PR DESCRIPTION
First of all, thank you fore the fantastic work so far. As I set up a litle k8s-cluster in the Hetzner Cloud with the help of this guide, I noticed that the route, which routes traffic from the Weave Net Interface over the Wireguard interface, is not persistent and therefore doesn't survive a node reboot.

As the typical way to set up a persistent routes in `/etc/network/interfaces` doesnt't work in this case, because the wg0 interface gets initialized after the physical/virtual interfaces in  `/etc/network/interfaces`, I set up a systemd service unit, which waits for the *wg-quick@wg0.service* and after that adds the route. This seems to work well. I'm interested in your opinion.