### PR TITLE
Add link to DigitalOcean DNS provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@ The NGINX ingress controller is quite flexible and supports a whole bunch of [co
 ![Terraform](assets/terraform.png) [`dns/cloudflare`](https://github.com/hobby-kube/provisioning/tree/master/dns/cloudflare)
 ![Terraform](assets/terraform.png) [`dns/google`](https://github.com/hobby-kube/provisioning/tree/master/dns/google)
 ![Terraform](assets/terraform.png) [`dns/aws`](https://github.com/hobby-kube/provisioning/tree/master/dns/aws)
+![Terraform](assets/terraform.png) [`dns/digitalocean`](https://github.com/hobby-kube/provisioning/tree/master/dns/digitalocean)
 
 At this point we could use a domain name and put some DNS entries into place. To serve web traffic it's enough to create an A record pointing to the public IP address of kube1 plus a wildcard entry to be able to use subdomains:
 


### PR DESCRIPTION
[This PR in the provisioning project](https://github.com/hobby-kube/provisioning/pull/23) was merged yesterday which adds support for using DigitalOcean's DNS, so this just adds a link to that in the readme next to the other DNS providers.