### PR TITLE
Replace kube-lego with cert-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,13 +522,10 @@ Additionally, it might be a good idea to assign a subdomain to each host, e.g. k
 
 Thanks to [Let’s Encrypt](https://letsencrypt.org/) and a project called [cert-manager](https://github.com/jetstack/cert-manager) it's incredibly easy to obtain free certificates for any domain name pointing at our Kubernetes cluster. Setting this service up takes no time and it plays well with the NGINX ingress controller we deployed earlier. These are the related manifests:
 
-- [ingress/tls/cert-manager-resources.yaml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/cert-manager-resources.yaml),
-- [ingress/tls/cert-manager.yaml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/cert-manager.yaml),
-- [ingress/tls/certificate.yaml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/certificate.yaml).
+- [ingress/tls/cert-manager-resources.yml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/cert-manager-resources.yml),
+- [ingress/tls/cert-manager.yml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/cert-manager.yml),
 
-Before deploying using the manifests above, make sure to:
-- replace the email address a in `ingress/tls/cert-manager.yaml` with your own,
-- configure all domains and hosts that need to be managed in `ingress/tls/certificate.yaml`.
+Before deploying using the manifests above, make sure to replace the email address a in `ingress/tls/cert-manager.yml` with your own.
 
 To enable certificates for a service, the ingress manifest needs to be slightly extended:
 
@@ -538,10 +535,10 @@ kind: Ingress
 metadata:
   name: example-ingress
   annotations:
-    kubernetes.io/tls-acme: "true" # enable certificates
+    kubernetes.io/tls-acme: "true" # enable certificates defined in tls section below
     kubernetes.io/ingress.class: "nginx"
 spec:
-  tls: # specify domains to fetch certificates for
+  tls:
   - hosts:
     - example.com
     secretName: ingress-tls

--- a/README.md
+++ b/README.md
@@ -520,12 +520,15 @@ Additionally, it might be a good idea to assign a subdomain to each host, e.g. k
 
 ### Obtaining SSL/TLS certificates
 
-Thanks to [Let’s Encrypt](https://letsencrypt.org/) and a project called [kube-lego](https://github.com/jetstack/kube-lego) it's incredibly easy to obtain free certificates for any domain name pointing at our Kubernetes cluster. Setting this service up takes no time and it plays well with the NGINX ingress controller we deployed earlier. These are the related manifests:
+Thanks to [Let’s Encrypt](https://letsencrypt.org/) and a project called [cert-manager](https://github.com/jetstack/cert-manager) it's incredibly easy to obtain free certificates for any domain name pointing at our Kubernetes cluster. Setting this service up takes no time and it plays well with the NGINX ingress controller we deployed earlier. These are the related manifests:
 
-- [ingress/tls/deployment.yml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/deployment.yml)
-- [ingress/tls/configmap.yml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/configmap.yml)
+- [ingress/tls/cert-manager-resources.yaml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/cert-manager-resources.yaml),
+- [ingress/tls/cert-manager.yaml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/cert-manager.yaml),
+- [ingress/tls/certificate.yaml](https://github.com/hobby-kube/manifests/blob/master/ingress/tls/certificate.yaml).
 
-Before deploying kube-lego using the manifests above, make sure to replace the email address in `ingress/tls/configmap.yml` with your own.
+Before deploying using the manifests above, make sure to:
+- replace the email address a in `ingress/tls/cert-manager.yaml` with your own,
+- configure all domains and hosts that need to be managed in `ingress/tls/certificate.yaml`.
 
 To enable certificates for a service, the ingress manifest needs to be slightly extended:
 
@@ -540,10 +543,10 @@ metadata:
 spec:
   tls: # specify domains to fetch certificates for
   - hosts:
-    - service.example.com
-    secretName: example-service-tls
+    - example.com
+    secretName: ingress-tls
   rules:
-  - host: service.example.com
+  - host: www.example.com
     http:
       paths:
       - path: /
@@ -552,7 +555,7 @@ spec:
           servicePort: example-service-http
 ```
 
-After applying this manifest, kube-lego will try to obtain a certificate for service.example.com and reload the NGINX configuration to enable TLS. Make sure to check the logs of the kube-lego pod if something goes wrong.
+After applying this manifest, `cert-manager` will try to obtain a certificate for `www.example.com` and reload the NGINX configuration to enable TLS. Make sure to check the logs of the `cert-manager` pod if something goes wrong.
 
 NGINX will automatically redirect clients to HTTPS whenever TLS is enabled. In case you still want to serve traffic on HTTP, add `ingress.kubernetes.io/ssl-redirect: "false"`  to the list of annotations.
 


### PR DESCRIPTION
Related PR with changed manifests: https://github.com/hobby-kube/manifests/pull/5/files