### PR TITLE
getting the kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,11 +338,12 @@ Kubernetes is built around openness, so it's up to us to choose and install a su
 
 ```sh
 # create symlink for the current user in order to gain access to the API server with kubectl
+# or alternatively tell kubectl to use this file: export KUBECONFIG=/etc/kubernetes/admin.conf
 [ -d $HOME/.kube ] || mkdir -p $HOME/.kube
 ln -s /etc/kubernetes/admin.conf $HOME/.kube/config
 
 # install Weave Net
-kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version | base64 | tr -d '\n')"
+kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=$(kubectl version --short=true | grep Server | cut -d "v" -f 3 | cut -d "." -f 1-2)"
 
 # allow traffic on the newly created weave network interface
 ufw allow in on weave


### PR DESCRIPTION
This appears to be broken (although I'm using debian9 + 1.14 so maybe its just me..  but the hash 404's)

Another option (in the interests of keeping it less "magic") might be to to keep it hard-coded.

EG:

```
apt install kubelet=1.14.0-00 kubeadm=1.14.0-00 kubectl=1.14.0-00
...
KUBECONFIG=/etc/kubernetes/admin.conf kubectl apply -f "https://cloud.weave.works/k8s/net?k8s-version=1.14"
```


Nice guide FWIW.. I'm busy converting it into ansible (for hcloud)

also.. just a thought.. but it may be worth documenting how traffic from the public IP gets thru... I'm assuming its this bad boy:  https://github.com/hobby-kube/manifests/blob/master/ingress/deployment.yml#L26

Regards
-David